### PR TITLE
Bug/10: Create recipe view model does not empty after recipe created

### DIFF
--- a/FeedUs.Presentation/DataAccess/SimpleJsonDataAccess.cs
+++ b/FeedUs.Presentation/DataAccess/SimpleJsonDataAccess.cs
@@ -35,9 +35,7 @@ public class SimpleJsonDataAccess : IDataAccess
     public async Task AddRecipeAsync(Recipe recipe)
     {
         var allRecipes = await GetRecipesAsync();
-        recipe.Id = allRecipes.Any()
-            ? allRecipes.Last().Id + 1
-            : 1;
+        recipe.Id = allRecipes.Any() ? allRecipes.Last().Id + 1 : 1;
         var newList = allRecipes.Append(recipe);
         await WriteToFile(newList);
     }

--- a/FeedUs.Presentation/Views/CreateRecipePage.xaml.cs
+++ b/FeedUs.Presentation/Views/CreateRecipePage.xaml.cs
@@ -21,5 +21,6 @@ public partial class CreateRecipePage : ContentPage
     {
         base.OnDisappearing();
         (BindingContext as CreateRecipeViewModel)?.OnViewDisappearing();
+        BindingContext = null;
     }
 }


### PR DESCRIPTION
Added null assignment to `BindingContext` on create recipe page disappearing so that previous recipe is no longer there